### PR TITLE
Simplify handling of command line arguments

### DIFF
--- a/ssh-key-algo
+++ b/ssh-key-algo
@@ -19,19 +19,16 @@ usage () {
 DIR=$(mktemp -d -t tmp.XXXXXXX)
 trap 'rm -fr "$DIR"' EXIT
 
-host=git@github.com
-if [ $# -eq 1 ]
-then
-  if [ "$1" = "--help" ] || [ "$1" = "-h" ]
-  then
-    usage
-    exit 0
-  fi
-  host="$1"
-elif [ $# -gt 1 ]
+host=${1:-"git@github.com"}
+if [ $# -gt 1 ]
 then
   usage
   exit 1
+fi
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]
+then
+  usage
+  exit 0
 fi
 
 echo "using: $(which ssh)"


### PR DESCRIPTION
Instead of nested if-then-elif, simplify the flow to:

 - Use "git@github.com" as default value if "$1" unset or null
 - If "$#" greater than 1, print usage and exit
 - Otherwise, check if "$1" is either "--help" or "-h", print usage
   and  exit