### PR TITLE
use "command -v" instead of "which" to locate ssh binary

### DIFF
--- a/ssh-key-algo
+++ b/ssh-key-algo
@@ -31,7 +31,7 @@ then
   exit 0
 fi
 
-echo "using: $(which ssh)"
+echo "using: $(command -v ssh)"
 
 # Disable connection reuse because we can't parse the output if that happens.
 ssh -vvv -oControlMaster=no -oControlPath=no "$host" >"$DIR/output" 2>&1


### PR DESCRIPTION
To support users who don't have `which(1)` installed, we can just use the shell builtin `command -v` instead.

This should have no functional impact except to support users lacking the `which(1)` command.