### PR TITLE
Fix detection with OpenSSH 7.6

### DIFF
--- a/ssh-key-algo
+++ b/ssh-key-algo
@@ -57,9 +57,10 @@ then
   exit 5
 fi
 
-grep "sign_and_send_pubkey" "$DIR/output" >"$DIR/processed"
+grep -E "sign_and_send_pubkey|Server accepts key" "$DIR/output" >"$DIR/processed"
 # This should be an algorithm like "rsa-sha2-512" or "ssh-ed25519".
 ALGO=$(sed -n -e 's/^.*signing using \([a-z0-9-]*\).*/\1/p' <"$DIR/processed")
+[ -z "$ALGO" ] && ALGO=$(sed -n -e 's/^.*Server accepts key: pkalg \([a-z0-9-]*\) blen.*/\1/p' <"$DIR/processed")
 # This will be something like "RSA" or "ECDSA".
 KEYTYPE=$(sed -n -e 's/^.*sign_and_send_pubkey: \([A-Za-z0-9]*\) .*:.*/\1/p' <"$DIR/processed")
 DENIED=$(grep "Permission denied (publickey)." "$DIR/output")


### PR DESCRIPTION
Right now, we look only at lines with "sign_and_send_pubkey", but in some OpenSSH versions, such as 7.6, those lines don't indicate whether SHA-2 is being used.  We can fix this by looking at the "Server accepts key" line, which contains the explicit algorithm name.

Note that it's technically possible for the server to accept the key and then refuse the signature if the signature is bad, but we know OpenSSH will not produce such a signature and GitHub will not otherwise refuse such a signature.  In addition, PuTTY will scream very loudly if this happens, so it's not likely that other servers will do so, either.

Fixes #14 