### PR TITLE
We only want the first result, this in case there is for instance a ProxyJumps configured.

### DIFF
--- a/ssh-key-algo
+++ b/ssh-key-algo
@@ -50,7 +50,8 @@ ssh -vvv -oControlMaster=no -oControlPath=no ${identity:+-i "$identity"} "$host"
 
 # Turn the OpenSSH version into one without dots.  For example, 7.2 becomes 72,
 # and 8.4 becomes 84.
-VERSION=$(sed -n -e 's/^OpenSSH_\([0-9]*\)\.\([0-9]\).*/\1\2/p' <"$DIR/output")
+# We only want the first result, this in case there is for instance a ProxyJumps configured.
+VERSION=$(sed -n -e 's/^OpenSSH_\([0-9]*\)\.\([0-9]\).*/\1\2/p' <"$DIR/output" | head -n 1)
 if [ -z "$VERSION" ];
 then
   echo "OpenSSH is not installed, can't determine key type."


### PR DESCRIPTION
This resolves running the script with ProxyJumps in .ssh/config where the version output can come up multiple times. We are only interested in the first one.

/cc @bk2204 